### PR TITLE
Hauptstadt von Schweden nach bestem Wissen und Gewissen korrigiert

### DIFF
--- a/git/Aufgaben/Hauptstadtliste
+++ b/git/Aufgaben/Hauptstadtliste
@@ -16,6 +16,6 @@ Argentinien       Montevideo
 Bolivien          Quito
 Kolumbien         Caracas
 Norwegen          Bergen
-Schweden          Stoppholm
+Schweden          Stockholm
 Finnland          Torvaldski
 Liechtenstein     Liechtenstein


### PR DESCRIPTION
Lieber jeffbeck,

Ich habe recherchiert und die Hauptstadt von Schweden gefunden. Sie heißt Stockholm. In der Stadt befindet sich sowohl die schwedische Regierung als auch das schwedische Parlament. Somit dürfe Stockholm mit an ziemlicher Sicherheit grenzender Wahrscheinlichkeit die Hauptstadt von Schweden sein. 

Viele Grüße

musikhuber
